### PR TITLE
Segmenting dmd

### DIFF
--- a/framework/CodeInterfaces/RELAP5/RELAPparser.py
+++ b/framework/CodeInterfaces/RELAP5/RELAPparser.py
@@ -143,8 +143,8 @@ class RELAPparser():
       if self.maxNumberOfDecks > 1:
         temp.append('*'+' deckNum: '+str(deckNum)+'\n')
       for j in sorted(modiDictionaryList):
-        for var in sorted(modiDictionaryList[j]):
-          temp.append('* card: '+j+' word: '+str(var['position'])+' value: '+str(var['value'])+'\n')
+            for var in modiDictionaryList[j]:
+              temp.append('* card: '+j+' word: '+str(var['position'])+' value: '+str(var['value'])+'\n')
       temp.append('*RAVEN INPUT VALUES\n')
 
       temp+=self.deckLines[deckNum]

--- a/framework/Driver.py
+++ b/framework/Driver.py
@@ -128,10 +128,11 @@ if __name__ == '__main__':
   printStatement()
 
   checkVersions()
-
+  ## Initializing command line options
   verbosity      = 'all'
   interfaceCheck = False
   interactive = Interaction.No
+  
   workingDir = os.getcwd()
 
   ## Remove duplicate command line options and preserve order so if they try

--- a/framework/Models/ROM.py
+++ b/framework/Models/ROM.py
@@ -481,7 +481,7 @@ class ROM(Dummy):
     """
     inputToROM       = self._inputToInternal(request)
     # Check if the inputs sent to the ROM are consistent what what is expected (Addressing issue #1027 )
-    
+
     # Right now, the fix is to give a more informative error message that alerts the user of the inconsistancy
     # between the passed inputs and the expected ones.
     ## TODO: This method can be made smart enough to extract the needed inputs and ignore any additional ones.

--- a/framework/Models/ROM.py
+++ b/framework/Models/ROM.py
@@ -486,7 +486,7 @@ class ROM(Dummy):
     # between the passed inputs and the expected ones.
     ## TODO: This method can be made smart enough to extract the needed inputs and ignore any additional ones.
     if  not all(input in self.initializationOptionDict['Features'] for input in inputToROM.keys()):
-          self.raiseAnError(IOError, "Inputs passed to ROM are: ",inputToROM.keys(), ", while expected are: ",self.initializationOptionDict['Features'], ". Please check your inputs!")
+         self.raiseAnError(IOError, "Inputs passed to ROM are: ",inputToROM.keys(), ", while expected are: ",self.initializationOptionDict['Features'], ". Please check your inputs!")
     outputEvaluation = self.supervisedEngine.evaluate(inputToROM)
     # assure numpy array formatting # TODO can this be done in the supervised engine instead?
     for k,v in outputEvaluation.items():

--- a/framework/SupervisedLearning/SupervisedLearning.py
+++ b/framework/SupervisedLearning/SupervisedLearning.py
@@ -255,6 +255,7 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta),MessageHandler.Mess
       Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning algorithm
       NB.the supervisedLearning object is committed to convert the dictionary that is passed (in), into the local format
       the interface with the kernels requires.
+      
       @ In, edict, dict, evaluation dictionary
       @ Out, evaluate, dict, {target: evaluated points}
     """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

