### PR TITLE
Niharika jimmy spsl postprocessor

### DIFF
--- a/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
+++ b/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
@@ -1,15 +1,15 @@
 \subsubsection{SparseSensing}
 \label{SparseSensing}
-The \textbf{SparseSensing} post-processor incorporates "PySensors", a Scikit-learn style Python package for the sparse placement of sensors for reconstruction tasks and classification tasks which will be added here soon.
+The \textbf{SparseSensing} post-processor incorporates ''PySensors", a Scikit-learn style Python package for the sparse placement of sensors for reconstruction tasks and classification tasks which will be added here soon.
 
 Sparse sensor placement concerns the problem of selecting a small subset of sensor or measurement locations in a way that allows one to perform some task nearly as well as if one had access to measurements at every location.
 
 This post-processor provides objects designed for the tasks of reconstruction and classification. See
 
 \begin{itemize}
-    \item Manohar, Krithika, et al. "Data-driven sparse sensor placement for reconstruction: Demonstrating the benefits of exploiting known patterns." IEEE Control Systems Magazine 38.3 (2018): 63-86 for more information about the PySensors approach to reconstruction problems and,
-    \item Brunton, Bingni W., et al. "Sparse sensor placement optimization for classification." SIAM Journal on Applied Mathematics 76.5 (2016): 2099-2122 for classification and,
-    \item de Silva, Brian M., et al. "PySensors: A Python package for sparse sensor placement." arXiv preprint arXiv:2102.13476 (2021) contains a full literature review along with examples and additional tips for using PySensors effectively.
+    \item Manohar, Krithika, et al. ''Data-driven sparse sensor placement for reconstruction: Demonstrating the benefits of exploiting known patterns." IEEE Control Systems Magazine 38.3 (2018): 63-86 for more information about the PySensors approach to reconstruction problems and,
+    \item Brunton, Bingni W., et al. ''Sparse sensor placement optimization for classification." SIAM Journal on Applied Mathematics 76.5 (2016): 2099-2122 for classification and,
+    \item de Silva, Brian M., et al. ''PySensors: A Python package for sparse sensor placement." arXiv preprint arXiv:2102.13476 (2021) contains a full literature review along with examples and additional tips for using PySensors effectively.
 \end{itemize} 
 
 Some important terms related to sensor placement problems are : 
@@ -19,20 +19,20 @@ Some important terms related to sensor placement problems are :
 
     \item \textbf{Classification} is the problem of predicting which category an example belongs to, given a set of training data (e.g. determining whether digital photos are of dogs or cats).
 
-    \item \textbf{Bases} in which measurement data are represented can have a dramatic effect on performance. PySensors implements the three bases most commonly used for sparse sensor placement: raw measurements, SVD/POD/PCA modes, and random projections.These bases can be easily incorporated into either classification or reconstruction tasks. 
+    \item \textbf{Bases} in which measurement data are represented can have a dramatic effect on performance. PySensors implements the three bases most commonly used for sparse sensor placement: raw measurements, SVD/POD/PCA modes, and random projections. These bases can be easily incorporated into either classification or reconstruction tasks. 
 \end{itemize}
 
-ppType{SparseSensing post-processor}{SparseSensing}
+\ppType{SparseSensing post-processor}{SparseSensing}
 \begin{itemize}
-	\item \xmlNode{"Goal"}, \xmlDesc{The goal of the sparse sensor optimization (i.e., reconstruction or classification) should be filled in subType}.
-	\item \xmlNode{"TrainingData"}, \xmlDesc{The Dataobject containing the training data}
-	\item \xmlNode{"features"}, \xmlDesc{Features/inputs of the data model}
-	\item \xmlNode{"target"}, \xmlDesc{target of data model}
-	\item \xmlNode{"basis"}, \xmlDesc{The type of basis onto which the data are projected}
-	\item \xmlNode{"nModes"}, \xmlDesc{The number of modes retained}
-	\item \xmlNode{"nSensors"}, \xmlDesc{The number of sensors used}
-	\item \xmlNode{"threshold"}, \xmlDesc{The percentage of sensors used (i.e., nSensors/nFeatures)}
-	\item \xmlNode{"optimizer"}, \xmlDesc{"The type of optimizer used}
+	\item \xmlNode{Goal}, The goal of the sparse sensor optimization (i.e., reconstruction or classification) should be filled in subType.
+	\item \xmlNode{TrainingData}, The Dataobject containing the training data
+	\item \xmlNode{features}, Features/inputs of the data model
+	\item \xmlNode{target}, target of data model
+	\item \xmlNode{basis}, The type of basis onto which the data are projected
+	\item \xmlNode{nModes}, The number of modes retained
+	\item \xmlNode{nSensors}, The number of sensors used
+	\item \xmlNode{threshold}, The percentage of sensors used (i.e., nSensors/nFeatures)
+	\item \xmlNode{optimizer}, The type of optimizer used
 \end{itemize}
 
 \textbf{Example:}

--- a/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
+++ b/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
@@ -1,15 +1,15 @@
 \subsubsection{SparseSensing}
 \label{SparseSensing}
-The \textbf{SparseSensing} post-processor incorporates ''PySensors", a Scikit-learn style Python package for the sparse placement of sensors for reconstruction tasks and classification tasks which will be added here soon.
+The \textbf{SparseSensing} post-processor incorporates ``PySensors'', a Scikit-learn style Python package for the sparse placement of sensors for reconstruction tasks and classification tasks which will be added here soon.
 
 Sparse sensor placement concerns the problem of selecting a small subset of sensor or measurement locations in a way that allows one to perform some task nearly as well as if one had access to measurements at every location.
 
 This post-processor provides objects designed for the tasks of reconstruction and classification. See
 
 \begin{itemize}
-    \item Manohar, Krithika, et al. ''Data-driven sparse sensor placement for reconstruction: Demonstrating the benefits of exploiting known patterns." IEEE Control Systems Magazine 38.3 (2018): 63-86 for more information about the PySensors approach to reconstruction problems and,
-    \item Brunton, Bingni W., et al. ''Sparse sensor placement optimization for classification." SIAM Journal on Applied Mathematics 76.5 (2016): 2099-2122 for classification and,
-    \item de Silva, Brian M., et al. ''PySensors: A Python package for sparse sensor placement." arXiv preprint arXiv:2102.13476 (2021) contains a full literature review along with examples and additional tips for using PySensors effectively.
+    \item Manohar, Krithika, et al. ``Data-driven sparse sensor placement for reconstruction: Demonstrating the benefits of exploiting known patterns.'' IEEE Control Systems Magazine 38.3 (2018): 63-86 for more information about the PySensors approach to reconstruction problems and,
+    \item Brunton, Bingni W., et al. ``Sparse sensor placement optimization for classification.'' SIAM Journal on Applied Mathematics 76.5 (2016): 2099-2122 for classification and,
+    \item de Silva, Brian M., et al. ``PySensors: A Python package for sparse sensor placement.'' arXiv preprint arXiv:2102.13476 (2021) contains a full literature review along with examples and additional tips for using PySensors effectively.
 \end{itemize} 
 
 Some important terms related to sensor placement problems are : 

--- a/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
+++ b/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
@@ -1,0 +1,60 @@
+\subsubsection{SparseSensing}
+\label{SparseSensing}
+The \textbf{SparseSensing} post-processor incorporates "PySensors", a Scikit-learn style Python package for the sparse placement of sensors for reconstruction tasks and classification tasks which will be added here soon.
+
+Sparse sensor placement concerns the problem of selecting a small subset of sensor or measurement locations in a way that allows one to perform some task nearly as well as if one had access to measurements at every location.
+
+This post-processor provides objects designed for the tasks of reconstruction and classification. See
+
+\begin{itemize}
+    \item Manohar, Krithika, et al. "Data-driven sparse sensor placement for reconstruction: Demonstrating the benefits of exploiting known patterns." IEEE Control Systems Magazine 38.3 (2018): 63-86 for more information about the PySensors approach to reconstruction problems and,
+    \item Brunton, Bingni W., et al. "Sparse sensor placement optimization for classification." SIAM Journal on Applied Mathematics 76.5 (2016): 2099-2122 for classification and,
+    \item de Silva, Brian M., et al. "PySensors: A Python package for sparse sensor placement." arXiv preprint arXiv:2102.13476 (2021) contains a full literature review along with examples and additional tips for using PySensors effectively.
+\end{itemize} 
+
+Some important terms related to sensor placement problems are : 
+
+\begin{itemize}
+    \item \textbf{Reconstruction} deals with predicting the values of a quantity of interest at different locations other than those where sensors are located. For example, one might predict the temperature at a point point in the middle of a fuel rod based on readings taken at various other positions. 
+
+    \item \textbf{Classification} is the problem of predicting which category an example belongs to, given a set of training data (e.g. determining whether digital photos are of dogs or cats).
+
+    \item \textbf{Bases} in which measurement data are represented can have a dramatic effect on performance. PySensors implements the three bases most commonly used for sparse sensor placement: raw measurements, SVD/POD/PCA modes, and random projections.These bases can be easily incorporated into either classification or reconstruction tasks. 
+\end{itemize}
+
+ppType{SparseSensing post-processor}{SparseSensing}
+\begin{itemize}
+	\item \xmlNode{"Goal"}, \xmlDesc{The goal of the sparse sensor optimization (i.e., reconstruction or classification) should be filled in subType}.
+	\item \xmlNode{"TrainingData"}, \xmlDesc{}
+	\item \xmlNode{"features"}, \xmlDesc{}
+	\item \xmlNode{"target"}, \xmlDesc{}
+	\item \xmlNode{"basis"}, \xmlDesc{}
+	\item \xmlNode{"nModes"}, \xmlDesc{}
+	\item \xmlNode{"nSensors"}, \xmlDesc{}
+	\item \xmlNode{"threshold"}, \xmlDesc{}
+	\item \xmlNode{"optimizer"}, \xmlDesc{}
+\end{itemize}
+
+\textbf{Example:}
+\begin{lstlisting}[style=XML]
+<Simulation>
+   ...
+   <Models>
+      ...
+      <PostProcessor name="mySPSL" subType="SparseSensing" verbosity="debug">
+      <Goal subType="reconstruction">
+        <TrainingData>myDO</TrainingData>
+        <features>x,y</features>
+        <target>v</target>
+        <basis>svd</basis> <!--Ddefault: svd-->
+        <nModes>5</nModes> <!--default: opt, allows the algorithm to pick nModes-->
+        <nSensors>5</nSensors><!--default: opt, allows the algorithm to pick nSensors-->
+        <threshold>0.2</threshold>
+        <optimizer>QR</optimizer><!--default: QR-->
+      </Goal>
+    </PostProcessor>
+    ...
+  </Models>
+   ...
+</Simulation>
+\end{lstlisting}

--- a/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
+++ b/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
@@ -31,7 +31,6 @@ Some important terms related to sensor placement problems are :
 	\item \xmlNode{basis}, The type of basis onto which the data are projected
 	\item \xmlNode{nModes}, The number of modes retained
 	\item \xmlNode{nSensors}, The number of sensors used
-	\item \xmlNode{threshold}, The percentage of sensors used (i.e., nSensors/nFeatures)
 	\item \xmlNode{optimizer}, The type of optimizer used
 \end{itemize}
 
@@ -44,12 +43,11 @@ Some important terms related to sensor placement problems are :
       <PostProcessor name="mySPSL" subType="SparseSensing" verbosity="debug">
       <Goal subType="reconstruction">
         <TrainingData>myDO</TrainingData>
-        <features>x,y</features>
-        <target>v</target>
+        <features>X (m),Y (m),Temperature (K)</features>
+        <target>Temperature (K)</target>
         <basis>svd</basis> <!--Ddefault: svd-->
-        <nModes>5</nModes> <!--default: opt, allows the algorithm to pick nModes-->
-        <nSensors>5</nSensors><!--default: opt, allows the algorithm to pick nSensors-->
-        <threshold>0.2</threshold>
+        <nModes>4</nModes> <!--default: opt, allows the algorithm to pick nModes-->
+        <nSensors>4</nSensors><!--default: opt, allows the algorithm to pick nSensors-->
         <optimizer>QR</optimizer><!--default: QR-->
       </Goal>
     </PostProcessor>

--- a/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
+++ b/doc/user_manual/PostProcessors/SparseSensingdocumentation.tex
@@ -25,14 +25,14 @@ Some important terms related to sensor placement problems are :
 ppType{SparseSensing post-processor}{SparseSensing}
 \begin{itemize}
 	\item \xmlNode{"Goal"}, \xmlDesc{The goal of the sparse sensor optimization (i.e., reconstruction or classification) should be filled in subType}.
-	\item \xmlNode{"TrainingData"}, \xmlDesc{}
-	\item \xmlNode{"features"}, \xmlDesc{}
-	\item \xmlNode{"target"}, \xmlDesc{}
-	\item \xmlNode{"basis"}, \xmlDesc{}
-	\item \xmlNode{"nModes"}, \xmlDesc{}
-	\item \xmlNode{"nSensors"}, \xmlDesc{}
-	\item \xmlNode{"threshold"}, \xmlDesc{}
-	\item \xmlNode{"optimizer"}, \xmlDesc{}
+	\item \xmlNode{"TrainingData"}, \xmlDesc{The Dataobject containing the training data}
+	\item \xmlNode{"features"}, \xmlDesc{Features/inputs of the data model}
+	\item \xmlNode{"target"}, \xmlDesc{target of data model}
+	\item \xmlNode{"basis"}, \xmlDesc{The type of basis onto which the data are projected}
+	\item \xmlNode{"nModes"}, \xmlDesc{The number of modes retained}
+	\item \xmlNode{"nSensors"}, \xmlDesc{The number of sensors used}
+	\item \xmlNode{"threshold"}, \xmlDesc{The percentage of sensors used (i.e., nSensors/nFeatures)}
+	\item \xmlNode{"optimizer"}, \xmlDesc{"The type of optimizer used}
 \end{itemize}
 
 \textbf{Example:}

--- a/doc/user_manual/postprocessor.tex
+++ b/doc/user_manual/postprocessor.tex
@@ -37,6 +37,7 @@ Currently, the following types are available in RAVEN:
   \item \textbf{TypicalHistoryFromHistorySet}
   \item \textbf{dataObjectLabelFilter}
   \item \textbf{TSACharacterizer}
+  \item \textbf{SparseSensing}
 \end{itemize}
 
 The specifications of these types must be defined within the XML block
@@ -144,6 +145,9 @@ In the following sections the specifications of each type are reported.
 
 %%%%%%%%%%%%%%% TSACharacterizer %%%%%%%%%%%%%%%%%%%
 \input{PostProcessors/TSACharacterizer.tex}
+
+%%%%%%%%%%%%%%% SparseSensing %%%%%%%%%%%%%%%%%%%
+\input {Postprocessors/SparseSensingdocumentation.tex}`
 
 
 %%%%%%%%%%%%%% InterfacedPostProcessors %%%%%%%%%%%%%%%%

--- a/doc/user_manual/postprocessor.tex
+++ b/doc/user_manual/postprocessor.tex
@@ -147,7 +147,7 @@ In the following sections the specifications of each type are reported.
 \input{PostProcessors/TSACharacterizer.tex}
 
 %%%%%%%%%%%%%%% SparseSensing %%%%%%%%%%%%%%%%%%%
-\input {Postprocessors/SparseSensingdocumentation.tex}`
+\input {PostProcessors/SparseSensingdocumentation.tex}`
 
 
 %%%%%%%%%%%%%% InterfacedPostProcessors %%%%%%%%%%%%%%%%


### PR DESCRIPTION
--------
Pull Request Description
--------
##### This PR is for adding documentation to doc/user_manual/PostProcessors/  in Raven for the new PostProcessor SparseSensing. 


##### Added SparseSensing documentation.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

