### PR TITLE
Minor issues after introducing minMaxList are fixed. 

### DIFF
--- a/ravenframework/Optimizers/RavenSampled.py
+++ b/ravenframework/Optimizers/RavenSampled.py
@@ -721,7 +721,6 @@ class RavenSampled(Optimizer):
       if 'max' in self._minMax:
         objValue *= -1
       toExport[self._objectiveVar[0]] = objValue
-
     else: # Multi Objective Optimization
       for i in range(len(self._objectiveVar)):
         objValue = rlz[self._objectiveVar[i]]
@@ -740,7 +739,7 @@ class RavenSampled(Optimizer):
         toExport[var] = rlz[var]
     # formatting
     toExport = dict((var, np.atleast_1d(val)) for var, val in toExport.items())
-    self._solutionExport.addRealization(toExport) # It will stop when it is final
+    self._solutionExport.addRealization(toExport)
 
   def _addToSolutionExport(self, traj, rlz, acceptable):
     """

--- a/ravenframework/Optimizers/RavenSampled.py
+++ b/ravenframework/Optimizers/RavenSampled.py
@@ -721,6 +721,7 @@ class RavenSampled(Optimizer):
       if 'max' in self._minMax:
         objValue *= -1
       toExport[self._objectiveVar[0]] = objValue
+
     else: # Multi Objective Optimization
       for i in range(len(self._objectiveVar)):
         objValue = rlz[self._objectiveVar[i]]
@@ -739,7 +740,7 @@ class RavenSampled(Optimizer):
         toExport[var] = rlz[var]
     # formatting
     toExport = dict((var, np.atleast_1d(val)) for var, val in toExport.items())
-    self._solutionExport.addRealization(toExport)
+    self._solutionExport.addRealization(toExport) # It will stop when it is final
 
   def _addToSolutionExport(self, traj, rlz, acceptable):
     """

--- a/ravenframework/Optimizers/RavenSampled.py
+++ b/ravenframework/Optimizers/RavenSampled.py
@@ -731,7 +731,7 @@ class RavenSampled(Optimizer):
     # constants and functions
     toExport.update(self.constants)
     toExport.update(dict((var, rlz[var]) for var in self.dependentSample if var in rlz))
-    # additional from from inheritors
+    # additional from inheritors
     toExport.update(self._addToSolutionExport(traj, rlz, acceptable))
     # check for anything else that solution export wants that rlz might provide
     for var in self._solutionExport.getVars():

--- a/ravenframework/Optimizers/parentSelectors/parentSelectors.py
+++ b/ravenframework/Optimizers/parentSelectors/parentSelectors.py
@@ -21,10 +21,15 @@
   Created June,16,2020
   @authors: Mohammad Abdo, Diego Mandelli, Andrea Alfonsi
 """
-
+# External Modules----------------------------------------------------------------------------------
 import numpy as np
 import xarray as xr
 from ...utils import randomUtils
+# External Modules----------------------------------------------------------------------------------
+
+# Internal Modules----------------------------------------------------------------------------------
+from ...utils.gaUtils import dataArrayToDict, datasetToDataArray
+# Internal Modules End------------------------------------------------------------------------------
 
 # For mandd: to be updated with RAVEN official tools
 from itertools import combinations
@@ -42,7 +47,7 @@ def rouletteWheel(population,**kwargs):
   """
   # Arguments
   pop = population
-  fitness = kwargs['fitness']
+  fitness = np.array([item for sublist in datasetToDataArray(kwargs['fitness'], list(kwargs['fitness'].keys())).data for item in sublist])  
   nParents= kwargs['nParents']
   # if nparents = population size then do nothing (whole population are parents)
   if nParents == pop.shape[0]:
@@ -62,11 +67,11 @@ def rouletteWheel(population,**kwargs):
     roulettePointer = randomUtils.random(dim=1, samples=1)
     # initialize Probability
     counter = 0
-    if np.all(fitness.data>=0) or np.all(fitness.data<=0):
-      selectionProb = fitness.data/np.sum(fitness.data) # Share of the pie (rouletteWheel)
+    if np.all(fitness>=0) or np.all(fitness<=0):
+      selectionProb = fitness/np.sum(fitness) # Share of the pie (rouletteWheel)
     else:
       # shift the fitness to be all positive
-      shiftedFitness = fitness.data + abs(min(fitness.data))
+      shiftedFitness = fitness + abs(min(fitness))
       selectionProb = shiftedFitness/np.sum(shiftedFitness) # Share of the pie (rouletteWheel)
     sumProb = selectionProb[counter]
 
@@ -109,11 +114,11 @@ def tournamentSelection(population,**kwargs):
     matrixOperationRaw[:,3] = np.transpose(constraintInfo.data)
     matrixOperation = np.zeros((popSize,len(matrixOperationRaw[0])))
   else:
-    fitness = kwargs['fitness']
+    fitness = np.array([item for sublist in datasetToDataArray(kwargs['fitness'], list(kwargs['fitness'].keys())).data for item in sublist])  
     multiObjectiveRanking = False
     matrixOperationRaw = np.zeros((popSize,2))
     matrixOperationRaw[:,0] = np.transpose(np.arange(popSize))
-    matrixOperationRaw[:,1] = np.transpose(fitness.data)
+    matrixOperationRaw[:,1] = np.transpose(fitness)
     matrixOperation = np.zeros((popSize,2))
 
   indexes = list(np.arange(popSize))

--- a/ravenframework/Optimizers/parentSelectors/parentSelectors.py
+++ b/ravenframework/Optimizers/parentSelectors/parentSelectors.py
@@ -105,13 +105,13 @@ def tournamentSelection(population,**kwargs):
     # the key rank is used in multi-objective optimization where rank identifies which front the point belongs to
     rank = kwargs['rank']
     crowdDistance = kwargs['crowdDistance']
-    constraintInfo = kwargs['constraint']
+    # constraintInfo = kwargs['constraint']
     multiObjectiveRanking = True
-    matrixOperationRaw = np.zeros((popSize, 4))
+    matrixOperationRaw = np.zeros((popSize, 3))    #NOTE if constraint is needed to eliminate chromosome violating constraints, then poopSize should be 4.
     matrixOperationRaw[:,0] = np.transpose(np.arange(popSize))
     matrixOperationRaw[:,1] = np.transpose(crowdDistance.data)
     matrixOperationRaw[:,2] = np.transpose(rank.data)
-    matrixOperationRaw[:,3] = np.transpose(constraintInfo.data)
+    # matrixOperationRaw[:,3] = np.transpose(constraintInfo.data)
     matrixOperation = np.zeros((popSize,len(matrixOperationRaw[0])))
   else:
     fitness = np.array([item for sublist in datasetToDataArray(kwargs['fitness'], list(kwargs['fitness'].keys())).data for item in sublist])  
@@ -144,18 +144,13 @@ def tournamentSelection(population,**kwargs):
       selectedParent[i,:] = pop.values[index,:]
   else:                            # multi-objective implementation of tournamentSelection
     for i in range(nParents):
-      if      matrixOperation[2*i,3] > matrixOperation[2*i+1,3]:  index = int(matrixOperation[2*i+1,0])
-      elif    matrixOperation[2*i,3] < matrixOperation[2*i+1,3]:  index = int(matrixOperation[2*i,0])
-      elif    matrixOperation[2*i,3] == matrixOperation[2*i+1,3]:  # if same number of constraints violations
-        if    matrixOperation[2*i,2] > matrixOperation[2*i+1,2]:
-          index = int(matrixOperation[2*i+1,0])
-        elif  matrixOperation[2*i,2] < matrixOperation[2*i+1,2]:
-          index = int(matrixOperation[2*i,0])
-        else: # same number of constraints and same rank case
-          if matrixOperation[2*i,1] > matrixOperation[2*i+1,1]:
-            index = int(matrixOperation[2*i,0])
-          else:
-            index = int(matrixOperation[2*i+1,0])
+      if      matrixOperation[2*i,2] > matrixOperation[2*i+1,2]:  index = int(matrixOperation[2*i+1,0])
+      elif    matrixOperation[2*i,2] < matrixOperation[2*i+1,2]:  index = int(matrixOperation[2*i,0])
+      elif    matrixOperation[2*i,2] == matrixOperation[2*i+1,2]:  # if same rank, then compare CD
+        if    matrixOperation[2*i,1] > matrixOperation[2*i+1,1]:  index = int(matrixOperation[2*i,0])
+        elif  matrixOperation[2*i,2] < matrixOperation[2*i+1,2]:  index = int(matrixOperation[2*i+1,0])
+        else: # same rank and same CD
+          index = int(matrixOperation[2*i+1,0])  #NOTE if rank and CD are same, then any chromosome can be selected.
       selectedParent[i,:] = pop.values[index,:]
 
   return selectedParent

--- a/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
+++ b/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
@@ -21,10 +21,15 @@
   Created June,16,2020
   @authors: Mohammad Abdo, Diego Mandelli, Andrea Alfonsi
 """
-
+# External Modules----------------------------------------------------------------------------------
 import numpy as np
 import xarray as xr
 from ravenframework.utils import frontUtils
+# External Modules End------------------------------------------------------------------------------
+
+# Internal Modules----------------------------------------------------------------------------------
+from ...utils.gaUtils import dataArrayToDict, datasetToDataArray
+# Internal Modules End------------------------------------------------------------------------------
 
 # @profile
 def ageBased(newRlz,**kwargs):
@@ -97,11 +102,12 @@ def fitnessBased(newRlz,**kwargs):
   else:
     popAge = kwargs['age']
 
-  offSpringsFitness = np.atleast_1d(kwargs['offSpringsFitness'])
+  offSpringsFitness = datasetToDataArray(kwargs['offSpringsFitness'], list(kwargs['offSpringsFitness'].keys())).data
+  offSpringsFitness = np.array([item for sublist in offSpringsFitness for item in sublist])
   offSprings = np.atleast_2d(newRlz[kwargs['variables']].to_array().transpose().data)
   population = np.atleast_2d(kwargs['population'].data)
-  popFitness = np.atleast_1d(kwargs['fitness'].data)
-
+  popFitness = datasetToDataArray(kwargs['fitness'], list(kwargs['fitness'].keys())).data
+  popFitness = np.array([item for sublist in popFitness for item in sublist])
   newPopulation = population
   newFitness = popFitness
   newAge = list(map(lambda x:x+1, popAge))
@@ -123,6 +129,7 @@ def fitnessBased(newRlz,**kwargs):
   newFitness = xr.DataArray(newFitness,
                             dims=['chromosome'],
                             coords={'chromosome':np.arange(np.shape(newFitness)[0])})
+  newFitness = newFitness.to_dataset(name = list(kwargs['fitness'].keys())[0])
 
   #return newPopulationArray,newFitness,newAge
   return newPopulationArray,newFitness,newAge,kwargs['popObjectiveVal']

--- a/ravenframework/utils/frontUtils.py
+++ b/ravenframework/utils/frontUtils.py
@@ -80,7 +80,7 @@ def rankNonDominatedFrontiers(data):
     @ out, nonDominatedRank, list, a list of length nPoints that has the ranking
                                   of the front passing through each point
   """
-  # tentative code block start
+  ## tentative code block start
   # import matplotlib.pyplot as plt
   # from mpl_toolkits.mplot3d import Axes3D
   # xdata = [item[0] for item in data]
@@ -109,7 +109,6 @@ def rankNonDominatedFrontiers(data):
   #   ax3d.text(x, y, z, label)
   # plt.title("Data")
   # plt.show()
-
   return nonDominatedRank
 
 def crowdingDistance(rank, popSize, objectives):
@@ -120,6 +119,13 @@ def crowdingDistance(rank, popSize, objectives):
     @ In, objectives, np.array, matrix contains objective values for each element of the population
     @ Out, crowdDist, np.array, array of crowding distances
   """
+  # # tentative code block start
+  # import matplotlib.pyplot as plt
+  # from mpl_toolkits.mplot3d import Axes3D
+  # xdata = [item[0] for item in data]
+  # ydata = [item[1] for item in data]
+  # zdata = [item[2] for item in data]
+
   crowdDist = np.zeros(popSize)
   fronts = np.unique(rank)
   fronts = fronts[fronts!=np.inf]

--- a/ravenframework/utils/frontUtils.py
+++ b/ravenframework/utils/frontUtils.py
@@ -122,9 +122,9 @@ def crowdingDistance(rank, popSize, objectives):
   # # tentative code block start
   # import matplotlib.pyplot as plt
   # from mpl_toolkits.mplot3d import Axes3D
-  # xdata = [item[0] for item in data]
-  # ydata = [item[1] for item in data]
-  # zdata = [item[2] for item in data]
+  # xdata = [item[0] for item in objectives]
+  # ydata = [item[1] for item in objectives]
+  # zdata = [item[2] for item in objectives]
 
   crowdDist = np.zeros(popSize)
   fronts = np.unique(rank)

--- a/ravenframework/utils/frontUtils.py
+++ b/ravenframework/utils/frontUtils.py
@@ -80,7 +80,7 @@ def rankNonDominatedFrontiers(data):
     @ out, nonDominatedRank, list, a list of length nPoints that has the ranking
                                   of the front passing through each point
   """
-  ## tentative code block start
+  # tentative code block start
   # import matplotlib.pyplot as plt
   # from mpl_toolkits.mplot3d import Axes3D
   # xdata = [item[0] for item in data]
@@ -109,6 +109,7 @@ def rankNonDominatedFrontiers(data):
   #   ax3d.text(x, y, z, label)
   # plt.title("Data")
   # plt.show()
+
   return nonDominatedRank
 
 def crowdingDistance(rank, popSize, objectives):
@@ -119,13 +120,6 @@ def crowdingDistance(rank, popSize, objectives):
     @ In, objectives, np.array, matrix contains objective values for each element of the population
     @ Out, crowdDist, np.array, array of crowding distances
   """
-  # # tentative code block start
-  # import matplotlib.pyplot as plt
-  # from mpl_toolkits.mplot3d import Axes3D
-  # xdata = [item[0] for item in objectives]
-  # ydata = [item[1] for item in objectives]
-  # zdata = [item[2] for item in objectives]
-
   crowdDist = np.zeros(popSize)
   fronts = np.unique(rank)
   fronts = fronts[fronts!=np.inf]

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/MinwoRepMultiObjective.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/MinwoRepMultiObjective.xml
@@ -9,7 +9,7 @@
   </TestInfo>
 
   <RunInfo>
-    <WorkingDir>Multi_MinwoReplacement_wo_constraints_20_5</WorkingDir>
+    <WorkingDir>Multi_MinwoReplacement_wo_constraints_20_5_M</WorkingDir>
     <Sequence>optimize,print</Sequence>
     <batchSize>1</batchSize>
   </RunInfo>
@@ -67,13 +67,14 @@
         <parentSelection>tournamentSelection</parentSelection>
         <reproduction>
           <crossover type="twoPointsCrossover">
-            <crossoverProb>0.7</crossoverProb>
+            <crossoverProb>0.8</crossoverProb>
           </crossover>
-          <mutation type="randomMutator">
-            <mutationProb>0.7</mutationProb>
+          <mutation type="swapMutator"> <!--swapMutator, scrambleMutator, bitFlipMutator, inversionMutator-->
+            <mutationProb>0.8</mutationProb>
           </mutation>
         </reproduction>
-        <fitness type="hardConstraint">  <!--'invLinear', 'feasibleFirst', 'hardConstraint' -->
+        <fitness type="feasibleFirst">  <!--'invLinear', 'feasibleFirst', 'hardConstraint' -->
+          <b>100</b>
         </fitness>
         <survivorSelection>rankNcrowdingBased</survivorSelection> <!--NOTE: Number of objectives must be >= 2 if user wants to use rankNcrowdingBased.-->
       </GAparams>
@@ -142,7 +143,7 @@
     <PointSet name="opt_export">
       <Input>trajID</Input>
       <!-- <Output>x1,x2,x3,x4,x5,x6,obj1,obj2,age,batchId,rank,CD,ConstraintEvaluation_expConstr3, ConstraintEvaluation_impConstr3,fitness,accepted </Output> -->
-      <Output>x1,x2,x3,x4,x5,x6,obj1,obj2,age,batchId,rank,CD,fitness,accepted </Output>
+      <Output>x1,x2,x3,x4,x5,x6,obj1,obj2,age,batchId,rank,CD,FitnessEvaluation_obj1,FitnessEvaluation_obj2,ConstraintEvaluation_expConstr3, ConstraintEvaluation_impConstr3,accepted </Output>
     </PointSet>
   </DataObjects>
 

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/MinwoRepMultiObjective.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/MinwoRepMultiObjective.xml
@@ -9,7 +9,7 @@
   </TestInfo>
 
   <RunInfo>
-    <WorkingDir>Multi_MinwoReplacement</WorkingDir>
+    <WorkingDir>Multi_MinwoReplacement_wo_constraints_20_5</WorkingDir>
     <Sequence>optimize,print</Sequence>
     <batchSize>1</batchSize>
   </RunInfo>
@@ -57,14 +57,13 @@
   <Optimizers>
     <GeneticAlgorithm name="GAopt">
       <samplerInit>
-        <limit>2</limit>
+        <limit>5</limit>
         <initialSeed>42</initialSeed>
         <writeSteps>every</writeSteps>
         <type>min,min</type>
       </samplerInit>
-
       <GAparams>
-        <populationSize>10</populationSize>
+        <populationSize>20</populationSize>
         <parentSelection>tournamentSelection</parentSelection>
         <reproduction>
           <crossover type="twoPointsCrossover">
@@ -74,7 +73,7 @@
             <mutationProb>0.7</mutationProb>
           </mutation>
         </reproduction>
-        <fitness type="rank_crowding">
+        <fitness type="hardConstraint">  <!--'invLinear', 'feasibleFirst', 'hardConstraint' -->
         </fitness>
         <survivorSelection>rankNcrowdingBased</survivorSelection> <!--NOTE: Number of objectives must be >= 2 if user wants to use rankNcrowdingBased.-->
       </GAparams>
@@ -110,7 +109,7 @@
   <Samplers>
     <MonteCarlo name="MC_samp">
       <samplerInit>
-        <limit>10</limit>
+        <limit>20</limit>
         <initialSeed>050877</initialSeed>
       </samplerInit>
       <variable name="x1">
@@ -142,7 +141,8 @@
     </PointSet>
     <PointSet name="opt_export">
       <Input>trajID</Input>
-      <Output>x1,x2,x3,x4,x5,x6,obj1,obj2,age,batchId,rank,CD,ConstraintEvaluation_expConstr3, ConstraintEvaluation_impConstr3,fitness,accepted </Output>
+      <!-- <Output>x1,x2,x3,x4,x5,x6,obj1,obj2,age,batchId,rank,CD,ConstraintEvaluation_expConstr3, ConstraintEvaluation_impConstr3,fitness,accepted </Output> -->
+      <Output>x1,x2,x3,x4,x5,x6,obj1,obj2,age,batchId,rank,CD,fitness,accepted </Output>
     </PointSet>
   </DataObjects>
 

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/testGAMinwRepConstrained.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/testGAMinwRepConstrained.xml
@@ -61,7 +61,7 @@
       </samplerInit>
 
       <GAparams>
-        <populationSize>10</populationSize>
+        <populationSize>20</populationSize>
         <parentSelection>tournamentSelection</parentSelection> <!-- rouletteWheel, tournamentSelection -->
         <reproduction>
           <crossover type="onePointCrossover">
@@ -101,7 +101,7 @@
   <Samplers>
     <MonteCarlo name="MC_samp">
       <samplerInit>
-        <limit>10</limit>
+        <limit>20</limit>
         <initialSeed>20021986</initialSeed>
       </samplerInit>
       <variable name="x1">

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/testGAMinwRepConstrained.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/testGAMinwRepConstrained.xml
@@ -55,14 +55,14 @@
   <Optimizers>
     <GeneticAlgorithm name="GAopt">
       <samplerInit>
-        <limit>20</limit>
+        <limit>5</limit>
         <initialSeed>42</initialSeed>
         <writeSteps>every</writeSteps>
       </samplerInit>
 
       <GAparams>
-        <populationSize>20</populationSize>
-        <parentSelection>rouletteWheel</parentSelection>
+        <populationSize>10</populationSize>
+        <parentSelection>tournamentSelection</parentSelection> <!-- rouletteWheel, tournamentSelection -->
         <reproduction>
           <crossover type="onePointCrossover">
             <crossoverProb>0.8</crossoverProb>
@@ -71,7 +71,7 @@
             <mutationProb>0.9</mutationProb>
           </mutation>
         </reproduction>
-        <fitness type="feasibleFirst"></fitness>
+        <fitness type="feasibleFirst"></fitness>  <!--'invLinear', 'feasibleFirst', 'hardConstraint' -->
         <survivorSelection>fitnessBased</survivorSelection>
       </GAparams>
 
@@ -101,7 +101,7 @@
   <Samplers>
     <MonteCarlo name="MC_samp">
       <samplerInit>
-        <limit>20</limit>
+        <limit>10</limit>
         <initialSeed>20021986</initialSeed>
       </samplerInit>
       <variable name="x1">

--- a/tests/framework/Optimizers/NSGAII/discrete/constrained/MultiSumwConst/MinwoRepMultiObjective.xml
+++ b/tests/framework/Optimizers/NSGAII/discrete/constrained/MultiSumwConst/MinwoRepMultiObjective.xml
@@ -57,14 +57,14 @@
   <Optimizers>
     <GeneticAlgorithm name="GAopt">
       <samplerInit>
-        <limit>2</limit>
+        <limit>3</limit>
         <initialSeed>42</initialSeed>
         <writeSteps>every</writeSteps>
-        <type>min</type>
+        <type>min, max</type>
       </samplerInit>
 
       <GAparams>
-        <populationSize>10</populationSize>
+        <populationSize>15</populationSize>
         <parentSelection>tournamentSelection</parentSelection>
         <reproduction>
           <crossover type="twoPointsCrossover">
@@ -110,7 +110,7 @@
   <Samplers>
     <MonteCarlo name="MC_samp">
       <samplerInit>
-        <limit>10</limit>
+        <limit>15</limit>
         <initialSeed>050877</initialSeed>
       </samplerInit>
       <variable name="x1">

--- a/tests/framework/Optimizers/NSGAII/discrete/constrained/MultiSumwConst/myConstraints.py
+++ b/tests/framework/Optimizers/NSGAII/discrete/constrained/MultiSumwConst/myConstraints.py
@@ -114,7 +114,17 @@ def impConstr4(Input):
     @ In, Input, object, RAVEN container
     @ out, g, float, implicit constraint 3 evaluation function
   """
-  g = Input.obj2 - 20
+  g = Input.obj2 - 16
+  return g
+
+def impConstr5(Input):
+  """
+    The implicit constraint involves variables from the output space, for example the objective variable or
+    a dependent variable that is not in the optimization search space
+    @ In, Input, object, RAVEN container
+    @ out, g, float, implicit constraint 3 evaluation function
+  """
+  g = 200 - Input.obj1
   return g
 
   """

--- a/tests/framework/Optimizers/NSGAII/discrete/constrained/MultiSumwConst/myConstraints.py
+++ b/tests/framework/Optimizers/NSGAII/discrete/constrained/MultiSumwConst/myConstraints.py
@@ -106,3 +106,35 @@ def impConstr3(Input):
   """
   g = 100 - Input.obj1
   return g
+
+def impConstr4(Input):
+  """
+    The implicit constraint involves variables from the output space, for example the objective variable or
+    a dependent variable that is not in the optimization search space
+    @ In, Input, object, RAVEN container
+    @ out, g, float, implicit constraint 3 evaluation function
+  """
+  g = Input.obj2 - 20
+  return g
+
+  """
+    Evaluates the implicit constraint function at a given point/solution ($\vec(x)$)
+    @ In, Input, object, RAVEN container
+    @ Out, g(inputs x1,x2,..,output or dependent variable), float, implicit constraint evaluation function
+            the way the constraint is designed is that
+            the constraint function has to be >= 0,
+            so if:
+            1) f(x,y) >= 0 then g = f
+            2) f(x,y) >= a then g = f - a
+            3) f(x,y) <= b then g = b - f
+            4) f(x,y)  = c then g = 1e-6 - abs((f(x,y) - c)) (equality constraint)
+  """
+  """
+    Let's assume that the constraint is:
+    $ x3+x4 < 8 $
+    then g the constraint evaluation function (which has to be > 0) is taken to be:
+    g = 8 - (x3+x4)
+    in this case if g(\vec(x)) < 0 then this x violates the constraint and vice versa
+    @ In, Input, object, RAVEN container
+    @ out, g, float, explicit constraint 1 evaluation function
+  """

--- a/tests/framework/Optimizers/NSGAII/discrete/constrained/ZDT1/ZDT_model.py
+++ b/tests/framework/Optimizers/NSGAII/discrete/constrained/ZDT1/ZDT_model.py
@@ -23,7 +23,7 @@ def evaluate(Inputs):
   for ind,var in enumerate(Inputs.keys()):
     # write the objective function here
     if (ind == 0) :
-      obj1 += Inputs[var]
+      obj1 = Inputs[var]
     if (ind != 0):
       Sum += Inputs[var]
   g = 1 + (9/len(Inputs.keys())*Sum )
@@ -39,3 +39,5 @@ def run(self,Inputs):
     @ Out, None
   """
   self.obj1,self.obj2 = evaluate(Inputs)
+
+


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Issue 1. After 2nd iteration, objectives and constraint values are not matching with population. It was not due to wrong calculations of objectives and constraints. It was due to the misalignment of population and objectives as a dictionary.  

Issue 2. When "max" is introduced, RAVEN first multiply a corresponding objective value with negative sign (i.e., -1). The new objective value (with minus sign) gives effect to constraint calculation. For instance, if a constraint says this objective needs to be smaller than 20, and the originally calculated objective value is 25. However, due to the -1 multiplication, it becomes -25 and suddenly it complies with a constraint.

##### What are the significant changes in functionality due to this change request?
This PR fixed the aforementioned issues.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

