### PR TITLE
Cleaning nsga ii fixes

### DIFF
--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -797,6 +797,8 @@ class GeneticAlgorithm(RavenSampled):
       else:
           objectiveVal = list(np.atleast_1d(rlz[self._objectiveVar[0]].data))
       self.objectiveVal = objectiveVal
+      self.population = rlz[self.toBeSampled.keys()].to_dataarray(dim="Gene").transpose()
+      self.population = self.population.assign_coords(chromosome=("RAVEN_sample_ID", range(self.population.shape[0]))).rename({"RAVEN_sample_ID": "chromosome"})
       g = constraintHandling(self, rlz, offSprings, objectiveVal, multiObjective=self._isMultiObjective)
 
       # 2 compute fitness

--- a/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
+++ b/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
@@ -148,9 +148,18 @@ def fitnessBased(newRlz,**kwargs):
   sorted_age = list(sorted_age)
   sorted_population = np.atleast_1d(list(sorted_population))
 
-  newPopulationSorted = sorted_population[:popSize]
-  newFitness = sorted_fitness[:popSize]
-  newAge = sorted_age[:popSize]
+  if len(sorted_population) < popSize:
+    #add orig population back if not enough generated.
+    curLen = len(sorted_population)
+    addLen = popSize - curLen
+    newPopulationSorted = np.vstack([sorted_population, newPopulationMerged[:addLen]])
+    newFitness = np.hstack([sorted_fitness,newFitness[:addLen]])
+    newAge = np.hstack([sorted_age, newAge[:addLen]])
+  else:
+    newPopulationSorted = sorted_population[:popSize]
+    newFitness = sorted_fitness[:popSize]
+    newAge = sorted_age[:popSize]
+
 
   newPopulationArray = xr.DataArray(newPopulationSorted,
                                     dims=['chromosome', 'Gene'],

--- a/ravenframework/utils/plotUtils.py
+++ b/ravenframework/utils/plotUtils.py
@@ -32,11 +32,13 @@ def errorFill(x, y, yerr, color=None, alphaFill=0.3, ax=None, logScale=False):
     @ Out, None
   """
   ax = ax if ax is not None else plt.gca()
-  if np.isscalar(yerr) or len(yerr) == len(y):
+  if np.isscalar(yerr) or (len(yerr) == len(y) and np.ndim(yerr) == 1):
     ymin = y - yerr
     ymax = y + yerr
   elif len(yerr) == 2:
     ymin, ymax = yerr
+  else:
+    print(f"Unhandled {yerr=} with {y=}")
   ax.plot(x, y, color=color)
   ax.fill_between(x, ymax, ymin, color=color, alpha=alphaFill)
   if logScale:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?

##### What are the significant changes in functionality due to this change request?
* Fixes population out of sync problem
* Fixes error when plotting just two values.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

